### PR TITLE
Fix an issue with Android Notification sound

### DIFF
--- a/MauiAudio/Platforms/Android/NotificationHelper.cs
+++ b/MauiAudio/Platforms/Android/NotificationHelper.cs
@@ -49,7 +49,7 @@ public static class NotificationHelper
 
         var name = "Local Notifications";
         var description = "The count from MainActivity.";
-        var channel = new NotificationChannel(CHANNEL_ID, name, NotificationImportance.Default)
+        var channel = new NotificationChannel(CHANNEL_ID, name, NotificationImportance.Min)
         {
             Description = description
         };


### PR DESCRIPTION
Fixed an issue where the Android notification Where sound will play each time player plays/pauses/goes next/goes previous

Now when user changes between states, it shouldn't play the notification sound no more